### PR TITLE
Add --color=no to py.test cmd

### DIFF
--- a/ftplugin/python/pytest.vim
+++ b/ftplugin/python/pytest.vim
@@ -342,7 +342,7 @@ endfunction
 
 
 function! s:RunInSplitWindow(path)
-    let cmd = "py.test --tb=short " . a:path
+    let cmd = "py.test --tb=short --color=no " . a:path
     if exists("g:ConqueTerm_Loaded")
         call conque_term#open(cmd, ['split', 'resize 20'], 0)
     else
@@ -548,7 +548,7 @@ endfunction!
 
 function! s:RunPyTest(path)
     let g:pytest_last_session = ""
-    let cmd = "py.test --tb=short " . a:path
+    let cmd = "py.test --tb=short --color=no " . a:path
     let out = system(cmd)
 
     " Pointers and default variables


### PR DESCRIPTION
Issue #11 comment by @gabehollombe where color=yes breaks Pytest.vim

if you have a pytest.ini that sets color=yes, you end up with control characters in your output.
this breaks the regex for parsing the results, and you never have any failures as a result.  passing --color=no
should remove this issue.
