### PR TITLE
Make pytest run doctests as well

### DIFF
--- a/ftplugin/python/pytest.vim
+++ b/ftplugin/python/pytest.vim
@@ -574,6 +574,7 @@ function! s:RunPyTest(path, doctest, ...)
     let cmd = 'py.test'
     if (a:doctest == 'True')
         let cmd = cmd . ' --doctest-modules'
+    endif
 
     if (len(parametrized) && parametrized != "0")
         let cmd = cmd . " -k " . parametrized . " --tb=short " . a:path

--- a/ftplugin/python/pytest.vim
+++ b/ftplugin/python/pytest.vim
@@ -344,7 +344,7 @@ endfunction
 
 
 function! s:RunInSplitWindow(path)
-    let cmd = "py.test --tb=short " . a:path
+    let cmd = "py.test --doctest-modules --tb=short " . a:path
     if exists("g:ConqueTerm_Loaded")
         call conque_term#open(cmd, ['split', 'resize 20'], 0)
     else
@@ -558,9 +558,9 @@ function! s:RunPyTest(path, ...)
     let g:pytest_last_session = ""
 
     if (len(parametrized) && parametrized != "0")
-        let cmd = "py.test -k " . parametrized . " --tb=short " . a:path
+        let cmd = "py.test --doctest-modules -k " . parametrized . " --tb=short " . a:path
     else
-        let cmd = "py.test --tb=short " . a:path
+        let cmd = "py.test --doctest-modules --tb=short " . a:path
     endif
 
     let out = system(cmd)
@@ -990,7 +990,7 @@ endfunction
 
 
 function! s:Pdb(path, ...)
-    let pdb_command = "py.test " . a:1 . " " . a:path
+    let pdb_command = "py.test --doctest-modules " . a:1 . " " . a:path
     if exists("g:ConqueTerm_Loaded")
         call conque_term#open(pdb_command, ['split', 'resize 20'], 0)
     else

--- a/ftplugin/python/pytest.vim
+++ b/ftplugin/python/pytest.vim
@@ -300,6 +300,15 @@ function! s:NameOfCurrentClass()
 endfunction
 
 
+function! s:PythonPathToModule()
+    let path = @%
+    let path = substitute(path, '.__init__.py', '.', 'g')
+    let path = substitute(path, '.py', '.', 'g')
+    let path = substitute(path, '/', '.', 'g')
+    return path
+endfunction
+
+
 function! s:NameOfCurrentMethod()
     normal! $<cr>
     let find_object = s:FindPythonObject('method')
@@ -887,7 +896,7 @@ function! s:ThisFunction(verbose, doctest, ...)
     call s:ClearAll()
     let c_name      = s:NameOfCurrentFunction()
     if (a:doctest == 'True')
-        let c_name = substitute(substitute(@%, '.py', '.', ''), '/', '.', 'g') . c_name
+        let c_name = s:PythonPathToModule() . c_name
     endif
 
     let is_parametrized = s:HasPythonDecorator(line('.'))
@@ -928,6 +937,9 @@ function! s:ThisClass(verbose, doctest, ...)
     let save_cursor = getpos('.')
     call s:ClearAll()
     let c_name      = s:NameOfCurrentClass()
+    if (a:doctest == 'True')
+        let c_name = s:PythonPathToModule() . c_name
+    endif
     let abspath     = s:CurrentPath()
     if (strlen(c_name) == 1)
         call setpos('.', save_cursor)
@@ -949,9 +961,9 @@ function! s:ThisClass(verbose, doctest, ...)
     endif
 
     if (a:verbose == 1)
-        call s:RunInSplitWindow(path)
+        call s:RunInSplitWindow(path, a:doctest)
     else
-        call s:RunPyTest(path)
+        call s:RunPyTest(path, a:doctest)
     endif
 endfunction
 

--- a/ftplugin/python/pytest.vim
+++ b/ftplugin/python/pytest.vim
@@ -924,7 +924,7 @@ function! s:ThisFunction(verbose, doctest, ...)
 endfunction
 
 
-function! s:ThisClass(verbose, ...)
+function! s:ThisClass(verbose, doctest, ...)
     let save_cursor = getpos('.')
     call s:ClearAll()
     let c_name      = s:NameOfCurrentClass()
@@ -956,7 +956,7 @@ function! s:ThisClass(verbose, ...)
 endfunction
 
 
-function! s:ThisFile(verbose, ...)
+function! s:ThisFile(verbose, doctest, ...)
     call s:ClearAll()
     let message = "py.test ==> Running tests for entire file"
     call s:Echo(message, 1)
@@ -972,9 +972,9 @@ function! s:ThisFile(verbose, ...)
     endif
 
     if (a:verbose == 1)
-        call s:RunInSplitWindow(abspath)
+        call s:RunInSplitWindow(abspath, a:doctest)
     else
-        call s:RunPyTest(abspath)
+        call s:RunPyTest(abspath, a:doctest)
     endif
 endfunction
 

--- a/ftplugin/python/pytest.vim
+++ b/ftplugin/python/pytest.vim
@@ -815,14 +815,20 @@ function! s:GreenBar()
 endfunction
 
 
-function! s:ThisMethod(verbose, ...)
+function! s:ThisMethod(verbose, doctest, ...)
     let save_cursor = getpos('.')
     call s:ClearAll()
+    let sep = '::'
     let m_name  = s:NameOfCurrentMethod()
     let is_parametrized = s:HasPythonDecorator(line('.'))
 
     let c_name  = s:NameOfCurrentClass()
+    if (a:doctest == 'True')
+        let c_name = s:PythonPathToModule() . c_name
+        let sep = '.'
+    endif
     let abspath = s:CurrentPath()
+
     if (strlen(m_name) == 1)
         call setpos('.', save_cursor)
         call s:Echo("Unable to find a matching method for testing")
@@ -842,7 +848,7 @@ function! s:ThisMethod(verbose, ...)
         let parametrized_flag = m_name
         let message = "py.test ==> Running test for parametrized method " . m_name
     else
-        let path =  abspath . "::" . c_name . "::" . m_name
+        let path =  abspath . "::" . c_name . sep . m_name
         let parametrized_flag = "0"
         let message = "py.test ==> Running test for method " . m_name
     endif
@@ -857,9 +863,9 @@ function! s:ThisMethod(verbose, ...)
         return
     endif
     if (a:verbose == 1)
-        call s:RunInSplitWindow(path)
+        call s:RunInSplitWindow(path, a:doctest)
     else
-       call s:RunPyTest(path, parametrized_flag)
+       call s:RunPyTest(path, a:doctest, parametrized_flag)
     endif
 endfunction
 

--- a/ftplugin/python/pytest.vim
+++ b/ftplugin/python/pytest.vim
@@ -935,7 +935,7 @@ function! s:ThisFunction(verbose, doctest, ...)
     if (a:verbose == 1)
         call s:RunInSplitWindow(path, a:doctest)
     else
-        call s:RunPyTest(path, c_name, a:doctest)
+        call s:RunPyTest(path, a:doctest, c_name)
     endif
 endfunction
 

--- a/ftplugin/python/pytest.vim
+++ b/ftplugin/python/pytest.vim
@@ -553,7 +553,7 @@ function! s:ResetAll()
 endfunction!
 
 
-function! s:RunPyTest(path, doctest ...)
+function! s:RunPyTest(path, doctest, ...)
     if (a:0 > 0)
       let parametrized = a:1
     else

--- a/ftplugin/python/pytest.vim
+++ b/ftplugin/python/pytest.vim
@@ -978,7 +978,7 @@ function! s:ThisFile(verbose, doctest, ...)
     endif
 endfunction
 
-function! s:ThisProject(verbose, ...)
+function! s:ThisProject(verbose, doctest, ...)
     call s:ClearAll()
     let message = "py.test ==> Running tests for entire project"
     call s:Echo(message, 1)
@@ -995,9 +995,9 @@ function! s:ThisProject(verbose, ...)
     endif
 
     if (a:verbose == 1)
-        call s:RunInSplitWindow(abspath)
+        call s:RunInSplitWindow(abspath, a:doctest)
     else
-        call s:RunPyTest(abspath)
+        call s:RunPyTest(abspath, a:doctest)
     endif
 endfunction
 


### PR DESCRIPTION
This is my little hack to get :Pytest to capture and run doctests. Currently only works when running doctests for a file, not sure how much it would take to get it to capture and run doctests for classes/methods/functions. To run a doctest, you need to use this sort of syntax:

```bash
py.test --doctest-modules path/to/file.py::path.to.file.function_name

py.test --doctest-modules path/to/file.py::path.to.file.ClassName

py.test --doctest-modules path/to/file.py::path.to.file.ClassName.method_name
```
and I'm not sure how to get access to those from inside pytest.vim (need to spend some more time looking at what's going on).
If it were possible to get that information, might be better to have a ```:Pytest doctest [file | class | method | function]``` command.

My temporary fix to #28 