### PR TITLE
Fix crash when running project tests

### DIFF
--- a/ftplugin/python/pytest.vim
+++ b/ftplugin/python/pytest.vim
@@ -334,8 +334,9 @@ function! s:ProjectPath()
     let projecttestdir = finddir('tests','.;')
     let projecttestfile = findfile('tests.py','.;')
 
-    if len(projecttestdir) == 0
+    if (len(projecttestdir) == 0)
         let projecttestdir = finddir('test', '.;')
+    endif
 
     if(len(projecttestdir) != 0)
         let path = fnamemodify(projecttestdir, ':p:h')


### PR DESCRIPTION
Whenever I tried to run `:Pytest project` I would get a crash regarding a missing `endif`.  I checked out the source and found that one seemed to be missing here; this change fixed the issue for me!