### PR TITLE
Check for method declarations across multiple lines.

### DIFF
--- a/ftplugin/python/pytest.vim
+++ b/ftplugin/python/pytest.vim
@@ -265,10 +265,10 @@ function! s:FindPythonObject(obj)
         let objregexp  = '\v^\s*(.*class)\s+(\w+)\s*'
         let max_indent_allowed = 0
     elseif (a:obj == "method")
-        let objregexp = '\v^\s*(.*def)\s+(\w+)\s*\(\s*(self[^)]*)'
+        let objregexp = '\v^\s*(.*def)\s+(\w+)\s*\(\_s*(self[^)]*)'
         let max_indent_allowed = 4
     else
-        let objregexp = '\v^\s*(.*def)\s+(\w+)\s*\(\s*(.*self)@!'
+        let objregexp = '\v^\s*(.*def)\s+(\w+)\s*\(\_s*(.*self)@!'
         let max_indent_allowed = orig_indent
     endif
 


### PR DESCRIPTION
This [regex](https://github.com/alfredodeza/pytest.vim/blob/master/ftplugin/python/pytest.vim#L268) doesn't detect method declarations that span multiple lines. It's a bit of an edge case.

For example

```
class TestSomething:
    def test_with_a_ridiculously_long_long_name_in_a_galaxy_far_far_away(
            self, some, parameters):
        ...
```

will be skipped,

I've changed regex to search to allow for methods with "def" and "self" that span multiple lines using the [`\_s`](http://vim.wikia.com/wiki/Search_across_multiple_lines) to detect for newlines/spaces/tabs. For some reason I worry though, regexes are always seem nontrivial to deal with
