### PR TITLE
include stderr from conftest in async and catch error with regex

### DIFF
--- a/ftplugin/python/pytest.vim
+++ b/ftplugin/python/pytest.vim
@@ -614,7 +614,6 @@ function! s:RunPyTest(path, ...) abort
       if type(job_id) != type(0)
         call job_stop(job_id)
       endif
-
       let b:job_id = job_start(cmd, {'close_cb': 'CloseHandler'})
 
       return
@@ -627,10 +626,15 @@ endfunction
 
 func! CloseHandler(channel)
   let stdout = ""
+  let stderr = ""
   while ch_status(a:channel, {'part': 'out'}) == 'buffered'
-    let stdout = stdout . ch_read(a:channel) . "\n"
+    let stdout = stdout . ch_read(a:channel, {'part': 'out'}) . "\n"
   endwhile
-  call s:HandleOutput(stdout)
+  while ch_status(a:channel, {'part': 'err'}) == 'buffered'
+    let stderr = stderr . ch_read(a:channel, {'part': 'err'}) . "\n"
+  endwhile
+
+  call s:HandleOutput(stdout . stderr)
 endfunc
 
 
@@ -664,6 +668,10 @@ function! s:HandleOutput(stdout)
             return
         elseif w =~ '\v\s+(ERRORS)\s+'
             call s:ParseErrors(out)
+            return
+        " conftest and plugin errors break all parsing
+        elseif w =~ '\v^E\s+\w+:\s+'
+            call s:ParseError(out)
             return
         elseif w =~ '\v^(.*)\s*ERROR:\s+'
             call s:ParseError(out)


### PR DESCRIPTION
This was a tricky one. By default `system()` produces both stderr and stdout, but because `pytest.vim` is using async behavior, then the channels must be read separately. 

This PR adds support for reading stderr and including the stdout for parsing as well as using a separate regex to capture these types of breakage that happen outside of a test as it happens in conftest.py for example.

Fixes:

* https://github.com/alfredodeza/pytest.vim/issues/66
* https://github.com/alfredodeza/pytest.vim/issues/68
